### PR TITLE
John's changes

### DIFF
--- a/django/core/static/css/custom.css
+++ b/django/core/static/css/custom.css
@@ -155,7 +155,7 @@ main a {
 	text-align: center;
 	background-color: rgba(255,255,255,0.5);
 	color: white;
-	padding-top: 5px;
+	padding-top: 0.15em;
     cursor: pointer;
     line-height: 80px;
 }

--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -247,7 +247,7 @@ class ReferenceAdminView(GenericAdminView):
     """
     list_display = ('id', 'title', 'subtitle', 'authors_list', 'book_title', 'location', 'year', 'reference_type',
                     'reference_publisher', 'admin_published', 'meta_created_datetime')
-    list_display_links = ('id',)
+    list_display_links = ('id', 'title')
     list_filter = ('reference_type', 'reference_publisher', 'admin_published', 'meta_created_by')
     search_fields = ('title', 'subtitle', 'authors_list', 'editors', 'school', 'book_title',
                      'journal_title', 'volume', 'number', 'location', 'year', 'url', 'public_notes', 'admin_notes')

--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -152,7 +152,7 @@ class GenericAdminView(admin.ModelAdmin):
     list_display_links = ('id', 'name')
     list_filter = ('admin_published', 'meta_created_by')
     search_fields = ('name', 'description', 'admin_notes')
-    ordering = ('-id',)
+    ordering = ('name', 'id',)
     actions = (publish, unpublish)
     readonly_fields = ('meta_created_by', 'meta_created_datetime', 'meta_lastupdated_by', 'meta_lastupdated_datetime', 'meta_firstpublished_datetime')
 
@@ -252,6 +252,7 @@ class ReferenceAdminView(GenericAdminView):
     search_fields = ('title', 'subtitle', 'authors_list', 'editors', 'school', 'book_title',
                      'journal_title', 'volume', 'number', 'location', 'year', 'url', 'public_notes', 'admin_notes')
     exclude = ('author', 'linguistic_field', 'linguistic_notion', 'linguistic_tradition')
+    ordering = ('title',)
     filter_horizontal = ('reference',)
     inlines = [AuthorReferenceInline,
                LinguisticFieldReferenceInline,

--- a/django/researchdata/models.py
+++ b/django/researchdata/models.py
@@ -526,23 +526,23 @@ class Reference(models.Model):
 
         # Journal Article
         elif self.reference_type == SlReferenceType.objects.get(name='journal article'):
-            ref = "{authors} ({year}), '{title}.".format(authors=self.authors_list,
-                                                         year=self.year,
-                                                         title=self.title)
+            ref = "{authors} ({year}), '{title}'.".format(authors=self.authors_list,
+                                                          year=self.year,
+                                                          title=self.title)
             if self.subtitle:
-                ref += "' {}.".format(self.subtitle)
-            ref += " <em>{}</em> {}.".format(self.journal_title, self.volume)
+                ref += " {}.".format(self.subtitle)
+            ref += " <em>{}</em> {}".format(self.journal_title, self.volume)
             if self.number:
-                ref += "({})".format(self.number)
+                ref += " ({})".format(self.number)
             ref += ": {}-{}.".format(self.page_start, self.page_end)
             if self.url:
                 ref += " {}.".format(self.url)
 
         # PhD Thesis
         elif self.reference_type == SlReferenceType.objects.get(name='phd thesis'):
-            ref = "{authors} ({year}), '{title}.".format(authors=self.authors_list,
-                                                         year=self.year,
-                                                         title=self.title)
+            ref = "{authors} ({year}), '{title}'.".format(authors=self.authors_list,
+                                                          year=self.year,
+                                                          title=self.title)
             if self.subtitle:
                 ref += " {}.".format(self.subtitle)
             ref += "' PhD thesis, {}.".format(self.school)
@@ -560,16 +560,25 @@ class Reference(models.Model):
             if self.url:
                 ref += " {}.".format(self.url)
 
+        # Miscellaneous Author (year), title. Public notes.
+        elif self.reference_type == SlReferenceType.objects.get(name='miscellaneous'):
+            ref = "{authors} ({year}), {title}.".format(authors=self.authors_list,
+                                                        year=self.year,
+                                                        title=self.title)
+            if self.public_notes:
+                ref += " {}.".format(self.public_notes)
+
         # If none of above reference types
         else:
-            ref = "{authors} ({year}), '{title}.".format(authors=self.authors_list,
-                                                         year=self.year,
-                                                         title=self.title)
+            ref = "{authors} ({year}), '{title}'.".format(authors=self.authors_list,
+                                                          year=self.year,
+                                                          title=self.title)
             if self.subtitle:
                 ref += " {}.".format(self.subtitle)
-            ref += "'"
             if self.url:
                 ref += " {}.".format(self.url)
+            if self.public_notes:
+                ref += " {}.".format(self.public_notes)
 
         return ref
 


### PR DESCRIPTION
John's requested changes 2021-09-08:

-please could we have another 'Reference Type': Misc, which is set up as follows: Author (year), title. Public notes.

Nothing else. I want reference ID 88 to look like this, but choosing other options makes it appear with various 'none's. So reference ID 88 should look like:

Hock, Hans Henrich (2011), From poster child to enfant terrible: Finite relativization in Dravidian and Indo-Aryan. Presentation at the conference Finiteness in South Asian Languages, University of Tromsø, 10 June 2011.


-When adding a new reference and selecting 'Reference Publisher' from the drop-down list, it is quite hard to find what's already there, because the list is not alphabetical (but according to the order in which they were added, I suppose). I could go out and look at the list of publishers, but then I have to go out and back in every time. The obvious danger is that we will add doubles of publishers, because we don't see that the one we want is already there, and add new. Is there a way to reorder these dropdown lists to be alphabetical?

-I've also noticed two problems in how the 'Journal Article' type is displayed. For example, the article by Comrie appears like this:

Comrie, Bernard (1998), 'Rethinking the typology of relative clauses. Language Design 1.: 59-86.

But it should look like this:

Comrie, Bernard (1998), 'Rethinking the typology of relative clauses'. Language Design 1: 59-86.

That is, there is a missing close quote after the title(+subtitle), and an unwanted full stop between the volume and the colon. 
