### PR TITLE
Change from Orinst to AMES

### DIFF
--- a/django/core/templates/base.html
+++ b/django/core/templates/base.html
@@ -13,7 +13,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="LINGUINDIC research project website">
-        <meta name="keywords" content="linguindic, india, linguistics, research, john lowe, humanities, art, oxford, university, university of oxford, oriental institute">
+        <meta name="keywords" content="linguindic, india, linguistics, research, john lowe, humanities, art, oxford, university, university of oxford, faculty of asian and middle eastern studies">
         <meta name="author" content="University of Oxford">
 
         <!-- Fonts -->
@@ -124,13 +124,13 @@
 
                 <div id="footer-content-logos">
                     <a href="https://www.ox.ac.uk/"><img src="{% static 'images/logos/oxford.png' %}" alt="University of Oxford logo"></a>
-                    <a href="https://www.orinst.ox.ac.uk/"><img src="{% static 'images/logos/orinst.png' %}" alt="Oriental Institute logo"></a>
+                    <a href="https://www.ames.ox.ac.uk/"><img src="{% static 'images/logos/orinst.png' %}" alt="Faculty of Asian and Middle Eastern Studies logo"></a>
                     <a href="https://cordis.europa.eu/project/id/851990"><img src="{% static 'images/logos/erc.png' %}" alt="European Research Council logo"></a>
                 </div>
 
                 <div id="footer-content-text">
                     <p>
-                        This website has been developed as part of the LINGUINDIC research project, which is led by <a href="https://www.orinst.ox.ac.uk/people/john-j-lowe">Dr John Lowe</a> at the <a href="https://www.orinst.ox.ac.uk/">Oriental Institute</a>, <a href="https://www.ox.ac.uk/">University of Oxford</a>.
+                        This website has been developed as part of the LINGUINDIC research project, which is led by <a href="https://www.orinst.ox.ac.uk/people/john-j-lowe">Dr John Lowe</a> of the <a href="https://www.ames.ox.ac.uk/">Faculty of Asian and Middle Eastern Studies</a>, <a href="https://www.ox.ac.uk/">University of Oxford</a>.
                     </p>
                     <p>
                         The LINGUINDIC project has received funding from the <a href="https://erc.europa.eu/">European Research Council (ERC)</a>

--- a/django/core/templates/base.html
+++ b/django/core/templates/base.html
@@ -130,7 +130,7 @@
 
                 <div id="footer-content-text">
                     <p>
-                        This website has been developed as part of the LINGUINDIC research project, which is led by <a href="https://www.orinst.ox.ac.uk/people/john-j-lowe">Dr John Lowe</a> of the <a href="https://www.ames.ox.ac.uk/">Faculty of Asian and Middle Eastern Studies</a>, <a href="https://www.ox.ac.uk/">University of Oxford</a>.
+                        This website has been developed as part of the LINGUINDIC research project, which is led by <a href="https://www.ames.ox.ac.uk/people/john-j-lowe">Dr John Lowe</a> of the <a href="https://www.ames.ox.ac.uk/">Faculty of Asian and Middle Eastern Studies</a>, <a href="https://www.ox.ac.uk/">University of Oxford</a>.
                     </p>
                     <p>
                         The LINGUINDIC project has received funding from the <a href="https://erc.europa.eu/">European Research Council (ERC)</a>

--- a/django/general/templates/general/about-team.html
+++ b/django/general/templates/general/about-team.html
@@ -60,7 +60,7 @@
             Mike has a bachelor's degree in business management with information systems, as well as a master's degree in computing. As well as being a member of the LINGUINDIC team, Mike also works as a Senior Research Software Engineer at the University of Birmingham. He has over 8 years' experience of working in IT within the HE sector.
         </p>
         <p>
-            For more information, please visit <a href="https://www.orinst.ox.ac.uk/people/michael-allaway" target="_blank">Mike's profile</a>
+            For more information, please visit <a href="https://www.ames.ox.ac.uk/people/michael-allaway" target="_blank">Mike's profile</a>
         </p>
 
         <h2>Dr James Benson</h2>

--- a/django/general/templates/general/about-team.html
+++ b/django/general/templates/general/about-team.html
@@ -44,7 +44,7 @@
             Diana is part of the Research Facilitation team at the Humanities Division and provides administrative, HR, and finance support to the LINGUINDIC team.
         </p>
         <p>
-            Diana has a European Doctorate in History of Arts (Classical Archaeology) and has worked in various academic and administrative roles in the past, including at the Faculty of Classics, Wolfson College, and the Faculty of Oriental Studies. Besides her job with LINGUINDIC, Diana is also the Research Assistant for the Beazley Archive Pottery Database at the Faculty of Classics (University of Oxford)
+            Diana has a European Doctorate in History of Arts (Classical Archaeology) and has worked in various academic and administrative roles in the past, including at the Faculty of Classics, Wolfson College, and the Faculty of Asian and Middle Eastern Studies. Besides her job with LINGUINDIC, Diana is also the Research Assistant for the Beazley Archive Pottery Database at the Faculty of Classics (University of Oxford)
         </p>
         <p>
             For more information, please visit <a href="https://www.classics.ox.ac.uk/people/dr-diana-rodriguez-perez#tab-279511" target="_blank">Diana's profile</a>


### PR DESCRIPTION
At Oxford, the "Faculty of Oriental Studies" has changed to the "Faculty of Asian and Middle Eastern Studies" so this PR updates this throughout (apart from email and logo, which are still waiting to be updated)