### PR TITLE
tidied structure of main nav and database page

### DIFF
--- a/django/core/static/css/custom.css
+++ b/django/core/static/css/custom.css
@@ -128,6 +128,10 @@ nav a:hover,
     color: #937200;
 }
 
+nav hr {
+    margin: 0.5em 0;
+}
+
 /* ---------- Main ---------- */
 
 main {
@@ -247,6 +251,16 @@ main a {
 
 #about-outputs li {
     margin: 1.5em 0;
+}
+
+#about-database-link {
+    display: block;
+    width: fit-content;
+    margin: 3em auto;
+    padding: 0.6em 1.3em 0.4em 1.3em;
+    border-radius: 0.2em;
+    background: #643d25;
+    color: #eedac3;
 }
 
 /* ---------- Browse ---------- */

--- a/django/core/static/css/custom_large.css
+++ b/django/core/static/css/custom_large.css
@@ -1,13 +1,17 @@
 @media (min-width: 992px) {
     /* ---------- Navigation ---------- */
 
+    .navbar {
+        padding-right: 3em;
+    }
+
     .navbar-brand {
         padding-left: 0.3em;
     }
 
     .nav-link {
-        margin-left: 0.7em;
-        margin-right: 0.7em;
+        margin-left: 1em;
+        margin-right: 1em;
         margin-top: 0.2em;
     }
 

--- a/django/core/templates/base.html
+++ b/django/core/templates/base.html
@@ -41,12 +41,12 @@
     </head>
 
     <body>
-        
+
         <!-- jQuery (has to load at start of page, as some templates that extend from this base template include jQuery in them) -->
         <script
-			  src="https://code.jquery.com/jquery-3.5.1.min.js"
-			  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
-			  crossorigin="anonymous"></script>
+              src="https://code.jquery.com/jquery-3.5.1.min.js"
+              integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+              crossorigin="anonymous"></script>
 
         <!-- Navigation bar -->
         <nav class="navbar fixed-top navbar-expand-lg">
@@ -63,19 +63,9 @@
                     <li class="nav-item">
                         <a class="nav-link{% if request.path == "/" %} active{% endif %}" href="{% url 'welcome' %}">Welcome</a>
                     </li>
-                    <!-- About -->
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle{% if "/about/" in request.path %} active{% endif %}" href="#" id="navbarDropdownMenuLinkAbout" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        About
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkAbout">
-                            <a class="dropdown-item" href="{% url 'about-project' %}">Project</a>
-                            <a class="dropdown-item" href="{% url 'about-database' %}">Database</a>
-                            <a class="dropdown-item" href="{% url 'about-team' %}">Team</a>
-                            <a class="dropdown-item" href="{% url 'about-funding' %}">Funding</a>
-                            <a class="dropdown-item" href="{% url 'about-events' %}">Events</a>
-                            <a class="dropdown-item" href="{% url 'about-outputs' %}">Research Outputs</a>
-                        </div>
+                    <!-- Database -->
+                    <li class="nav-item">
+                        <a class="nav-link{% if "/about/database/" in request.path %} active{% endif %}" href="{% url 'about-database' %}">Database</a>
                     </li>
                     <!-- Browse -->
                     <li class="nav-item dropdown">
@@ -83,21 +73,27 @@
                         Browse
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkBrowse">
+                            <a class="dropdown-item" href="{% url 'browse-linguisticnotions-list' %}">Linguistic Notions</a>
+                            <hr>
                             <a class="dropdown-item" href="{% url 'browse-authors-list' %}">Authors</a>
                             <a class="dropdown-item" href="{% url 'browse-linguisticfields-list' %}">Linguistic Fields</a>
-                            <a class="dropdown-item" href="{% url 'browse-linguisticnotions-list' %}">Linguistic Notions</a>
                             <a class="dropdown-item" href="{% url 'browse-linguistictraditions-list' %}">Linguistic Traditions</a>
                             <a class="dropdown-item" href="{% url 'browse-sanskritwords-list' %}">Sanskrit Words</a>
                             <a class="dropdown-item" href="{% url 'browse-texts-list' %}">Texts</a>
                         </div>
                     </li>
-                    <!-- Visualise -->
-                    <li class="nav-item">
-                        <a class="nav-link{% if "/visualise/" in request.path %} active{% endif %}" href="{% url 'visualise' %}">Visualise</a>
-                    </li>
-                    <!-- Help -->
-                    <li class="nav-item">
-                        <a class="nav-link{% if "/help/" in request.path %} active{% endif %}" href="{% url 'help' %}">Help</a>
+                    <!-- About -->
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle{% if "/about/" in request.path %} active{% endif %}" href="#" id="navbarDropdownMenuLinkAbout" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        About
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkAbout">
+                            <a class="dropdown-item" href="{% url 'about-project' %}">Project</a>
+                            <a class="dropdown-item" href="{% url 'about-team' %}">Team</a>
+                            <a class="dropdown-item" href="{% url 'about-funding' %}">Funding</a>
+                            <a class="dropdown-item" href="{% url 'about-events' %}">Events</a>
+                            <a class="dropdown-item" href="{% url 'about-outputs' %}">Outputs</a>
+                        </div>
                     </li>
                     {% if user.is_staff %}
                         <!-- Admin Dashboard -->

--- a/django/general/templates/general/about-database.html
+++ b/django/general/templates/general/about-database.html
@@ -8,20 +8,23 @@
     <div class="container">
         <h2>The LINGUINDIC Database</h2>
         <p>
-            The primary aim of our database is to present ancient Indian linguistic thought in the context of modern Western linguistic categories and approaches, and thereby to draw connections between the two.
+            The primary aim of our database is to present ancient Indian linguistic thought in the context of modern Western linguistic categories and approaches, and thereby to draw connections between the two. The core of our database consists of a series of entries on different linguistic notions.
         </p>
         <p>
-            In the <em>Browse</em> section of this website, you can search and browse different parts of the database. From the perspective of this project, the most important entries are the <a href="{% url 'browse-linguisticnotions-list' %}">'linguistic notion' entries</a>, which each addresses a specific object of study within modern Western linguistics, describing the corresponding ancient Indian notions and drawing connections between the two intellectual traditions. In doing this we necessarily refer to many ancient Indian <a href="{% url 'browse-authors-list' %}">authors</a>, <a href="{% url 'browse-texts-list' %}">texts</a>, <a href="{% url 'browse-linguistictraditions-list' %}">traditions of thought</a>, and <a href="{% url 'browse-sanskritwords-list' %}">Sanskrit words</a>. These are referenced and linked at the end of each entry, and also each have their own entries, providing further relevant information. These categories can also be searched and browsed separately.
+            <a id="about-database-link" href="{% url 'browse-linguisticnotions-list' %}">View the LINGUINDIC database</a>
+        </p>
+        <p>
+            Each linguistic notion addresses a specific object of study within modern Western linguistics, describing the corresponding ancient Indian notions and drawing connections between the two intellectual traditions. We want this database to be a valuable resource for linguists who want to access the intricacies of the Indian grammatical tradition, as well as to Sanskrit enthusiasts who wonder about the connections with modern Western notions or want to deepen into the Indian thought. 
+        </p>
+        <p>
+            We also refer to many ancient Indian <a href="{% url 'browse-authors-list' %}">authors</a>, <a href="{% url 'browse-texts-list' %}">texts</a>, <a href="{% url 'browse-linguistictraditions-list' %}">traditions of thought</a>, and <a href="{% url 'browse-sanskritwords-list' %}">Sanskrit words</a>. These are referenced and linked at the end of each entry, and also each have their own entries, providing further relevant information. These categories can also be searched and browsed separately. You can also consume the data via our open <a href="{% url 'api' %}">web API</a>, as well as interacting with our database visually via our website.
         </p>
         <p>
             The database is a work in progress; we aim to add new material frequently over the lifetime of the project, so please check back regularly for updates.
         </p>
         <p>
-            As well as interacting with our database visually via our website, you can also consume the data via our open <a href="{% url 'api' %}">web API</a>.
-        </p>
-        <p>
             If you have any questions or comments about the LINGUINDIC database then please email us at <a href="mailto:linguindic@ames.ox.ac.uk">linguindic@ames.ox.ac.uk</a>.
         </p>
     </div>
-    
+
 {% endblock %}

--- a/django/researchdata/views/common.py
+++ b/django/researchdata/views/common.py
@@ -111,7 +111,8 @@ def add_main_models_to_context(context, exclude):
             context['linguistictraditions'] = models.LinguisticTradition.objects.filter(admin_published=True)
 
         if exclude != 'reference':
-            context['references'] = models.Reference.objects.filter(admin_published=True)
+            context['references'] = models.Reference.objects.filter(admin_published=True).select_related('reference_type',
+            'reference_publisher')
 
         if exclude != 'sanskritword':
             context['sanskritwords'] = models.SanskritWord.objects.filter(admin_published=True)

--- a/django/researchdata/views/common.py
+++ b/django/researchdata/views/common.py
@@ -111,8 +111,7 @@ def add_main_models_to_context(context, exclude):
             context['linguistictraditions'] = models.LinguisticTradition.objects.filter(admin_published=True)
 
         if exclude != 'reference':
-            context['references'] = models.Reference.objects.filter(admin_published=True).select_related('reference_type',
-            'reference_publisher')
+            context['references'] = models.Reference.objects.filter(admin_published=True).select_related('reference_type', 'reference_publisher')
 
         if exclude != 'sanskritword':
             context['sanskritwords'] = models.SanskritWord.objects.filter(admin_published=True)


### PR DESCRIPTION
Original request:

Dear Michael,

Could you please update the database page, as well as the Browse menu? 

The database text is attached. As for the Browse menu: Please retain the 'browse' link at the top of the page, because it is useful. Also please hide 'visualise' and 'help', and add a tab 'database' which takes us to the about>database page. Maybe move  Linguistic Notions to the top of the drop-down tab under Browse, perhaps even set off with a line or something.

Best,

Adriana
