### PR TITLE
Yiming requested updates to outputs and events

### DIFF
--- a/django/general/templates/general/about-events.html
+++ b/django/general/templates/general/about-events.html
@@ -9,6 +9,11 @@
 
         <h2>Events</h2>
 
+        <h3>The 7th Beijing International Seminar on Tibetan Studies</h3>
+        <p>
+            We presented one paper at the 7th Beijing International Seminar on Tibetan Studies, 14-16 August 2023, Beijing, China. See <a href="{% url 'about-outputs' %}">'Research Outputs'</a>.
+        </p>
+
         <h3>Editing Ancient Grammatical Texts: Challenges and Opportunities</h3>
         <p>
             We presented one paper at the workshop on Editing Ancient Grammatical Texts: Challenges and Opportunities, 27-28 June 2023, Oxford, UK. See <a href="{% url 'about-outputs' %}">'Research Outputs'</a>.

--- a/django/general/templates/general/about-outputs.html
+++ b/django/general/templates/general/about-outputs.html
@@ -11,6 +11,9 @@
         <h3>Presentations</h3>
         <ul>
             <li>
+                'Some preliminary remarks on the Sanskrit grammatical manuscripts in the China Tibetology Research Center', Yiming Shen, presented at the 7th Beijing International Seminar on Tibetan Studies, 14-16 August 2023, Beijing, China.
+            </li>
+            <li>
                 ‘Editing the Anvayakalikā, a Sanskrit grammatical text on syntax’, Yiming Shen, presented at the workshop Editing Ancient Grammatical Texts: Challenges and Opportunities, 27-28 June 2023, Oxford, UK. <a href="{% static 'documents/editing_the_anvayakalika.pdf' %}" target="_blank">View handout</a>.
             </li>
             <li>


### PR DESCRIPTION
Dear Mike,
could you please add the following information to our website?

- In the 'Events' page ( https://www.linguindic.com/about/events/ ):
The 7th Beijing International Seminar on Tibetan Studies
We presented one paper at the 7th Beijing International Seminar on Tibetan Studies, 14-16 August 2023, Beijing, China. See 'Research Outputs'.

- In the 'Research Outputs' page ( https://www.linguindic.com/about/outputs/ ), under 'Presentations':
'Some preliminary remarks on the Sanskrit grammatical manuscripts in the China Tibetology Research Center', Yiming Shen, presented at the 7th Beijing International Seminar on Tibetan Studies, 14-16 August 2023, Beijing, China.

Many thanks!

Trust this message finds you well, and my best wishes,
Yiming